### PR TITLE
Fix dotnet install

### DIFF
--- a/install-mac.command
+++ b/install-mac.command
@@ -25,13 +25,13 @@ brew install tesseract
 brew install --cask wine-crossover
 brew install winetricks
 
-export WINEPREFIX=${HOME}/.wine/
+export WINEPREFIX=${HOME}/.wine-se/
 
 # Install .NET 4.8
 
-winetricks -q dotnet48
-winetricks -q lavfilters
-winetricks -q win10
+winetricks -q --force dotnet48
+winetricks -q --force lavfilters
+winetricks -q --force win10
 
 # Install Subtitle Edit portable
 
@@ -46,4 +46,3 @@ echo "subtitleeditw"
 echo "to run the GUI or"
 echo "subtitleeditw /help"
 echo "to run the CLI"
-

--- a/subtitleeditw
+++ b/subtitleeditw
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-WINEPREFIX=${HOME}/.wine/ wine64 "C:/Program Files/Subtitle Edit/SubtitleEdit.exe" "$@" 2>/dev/null
+WINEPREFIX=${HOME}/.wine-se/ wine64 "C:/Program Files/Subtitle Edit/SubtitleEdit.exe" "$@" 2>/dev/null


### PR DESCRIPTION
I had trouble installing Subtitle Edit with your script and modified it.
Problem was that dotnet was not installing, you have to --force that so I changed the script to --force.
Also I changed the default wineprefix folder to non-standard so existing .wine folders won't get overwritten.